### PR TITLE
replaceChild() 를 이용해서, 기존의 삭제-생성 과정을 대체했다.

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,9 +76,8 @@ function enterEditMode($noteContainer) {
 
   function handleSaveClick() {
     const newContent = $textarea.value;
-    $noteContainer.remove();
-    const $newNoteCotainer = createNoteElem(newContent);
-    $noteListContainer.append($newNoteCotainer);
+    const $newNoteContainer = createNoteElem(newContent);
+    $noteListContainer.replaceChild($newNoteContainer, $noteContainer);
     saveNotesToLocalStorage();
   }
 


### PR DESCRIPTION
기존의 remove() 를 이용해서, `$노트컨테이너`를 지우고 `$노트리스트컨테이너`에 다시 추가하는 과정은, 노트의 순서가 바뀌는 문제가 있었는데. 이를 **replaceChild()** 를 이용해서, 삭제가 아니라 **교체**하는 방식으로 해결했습니다.